### PR TITLE
연락하기 레이아웃 깨지는 부분 수정

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -12,7 +12,7 @@ permalink: /contact/
 	<li><a href="https://codeforseoul.slack.com/getting-started">코드포서울 슬랙 시작하기 | Getting started </a></li>
 </ul>
 
-<div class="row well">
+<div class="well">
 	<h2>Slack Clients</h2>
 	<div class="col-md-4 span_1_of_3 align_center no_right_padding small">
 		<div class="platform_icon finder_icon"></div>


### PR DESCRIPTION
코드포서울 홈페이지 연락하기 메뉴에 추가된 Slack Client 부분 테이블 레이아웃이 기존의 테이블과 맞지 않아서 수정하였습니다. 
